### PR TITLE
카카오, 네이버 소셜 로그인 시 성별, 연령대 정보를 가져오지 않도록 하라.

### DIFF
--- a/accounts/social_login/kakao_social_login.py
+++ b/accounts/social_login/kakao_social_login.py
@@ -30,9 +30,9 @@ class KakaoSocialLogin():
         user = User.objects.create(
             email=user_data_per_field['email'],
             username=username,
-            gender=user_data_per_field['gender'],
-            social=user_data_per_field['social'],
-            birth_year=user_data_per_field['birth_year'])
+            # gender=user_data_per_field['gender'],
+            # birth_year=user_data_per_field['birth_year'],
+            social=user_data_per_field['social'])
         return user
 
     def _generate_unique_username(self):
@@ -91,12 +91,16 @@ class KakaoSocialLogin():
         return response.json()
     
     def _parse_user_data(self, user_social_data):
+        """
+        성별, 연령대까지 가져오려 했으나 필요하지 않다고 판단하여 가져오지 않음
+        하지만 언제 쓸지 몰라서 일단 주석처리함
+        """
         user_data_per_field = dict()
 
         user_data_per_field['email'] = self._get_email(user_social_data)
-        user_data_per_field['gender'] = self._get_gender(user_social_data)
         user_data_per_field['social'] = self._get_social(user_social_data)
-        user_data_per_field['birth_year'] = self._get_brith_year(user_social_data)
+        # user_data_per_field['gender'] = self._get_gender(user_social_data)
+        # user_data_per_field['birth_year'] = self._get_brith_year(user_social_data)
 
         return user_data_per_field
 

--- a/accounts/social_login/naver_social_login.py
+++ b/accounts/social_login/naver_social_login.py
@@ -33,9 +33,9 @@ class NaverSocialLogin():
         user = User.objects.create(
             email=user_data_per_field['email'],
             username=username,
-            gender=user_data_per_field['gender'],
-            social=user_data_per_field['social'],
-            birth_year=user_data_per_field['birth_year'])
+            # gender=user_data_per_field['gender'],
+            # birth_year=user_data_per_field['birth_year'],
+            social=user_data_per_field['social'])
         return user
 
     def _generate_unique_username(self):
@@ -98,13 +98,17 @@ class NaverSocialLogin():
         
     
     def _parse_user_data(self, user_social_data):
+        """
+        성별, 연령대까지 가져오려 했으나 필요하지 않다고 판단하여 가져오지 않음
+        하지만 언제 쓸지 몰라서 일단 주석처리함
+        """
         user_data = user_social_data.json().get('response')
         user_data_per_field = dict()
 
         user_data_per_field['email'] = self._get_email(user_data)
-        user_data_per_field['gender'] = self._get_gender(user_data)
         user_data_per_field['social'] = self._get_social(user_data)
-        user_data_per_field['birth_year'] = self._get_brith_year(user_data)
+        # user_data_per_field['gender'] = self._get_gender(user_data)
+        # user_data_per_field['birth_year'] = self._get_brith_year(user_data)
 
         return user_data_per_field
 


### PR DESCRIPTION
- 소셜 로그인에서 이메일만 가져오도록 수정함
- 카카오, 네이버 앱에 redirect url을 수정하였음
- 이와 관련된 환경 변수를 notion에 업데이트함
    - .env, .ebextensions/01_variables.config